### PR TITLE
Add `npm-recursive-test` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "./node_modules/.bin/mocha"
   },
   "bin": {
-    "npm-recursive-install": "./recursive-install.js"
+    "npm-recursive-install": "./recursive-install.js",
+    "npm-recursive-test": "./recursive-test.js"
   },
   "repository": {
     "type": "git",

--- a/recursive-test.js
+++ b/recursive-test.js
@@ -3,14 +3,14 @@ var argv = require('yargs').argv
 var recursive = require('./recursive');
 var getPackageJsonLocations = recursive.getPackageJsonLocations;
 var filterRoot = recursive.filterRoot;
-var npmInstall = recursive.npmInstall;
+var npmTest = recursive.npmTest;
 
 function noop (x) { return x }
 
 if (require.main === module) {
   var exitCode = getPackageJsonLocations(process.cwd())
     .filter(argv.skipRoot ? filterRoot : noop)
-    .map(npmInstall)
+    .map(npmTest)
     .reduce(function (code, result) {
       return result.exitCode > code ? result.exitCode : code
     }, 0)

--- a/recursive.js
+++ b/recursive.js
@@ -1,0 +1,53 @@
+var path = require('path')
+var shell = require('shelljs')
+
+function getPackageJsonLocations (dirname) {
+  return shell.find(dirname)
+    .filter(function (fname) {
+      return !(fname.indexOf('node_modules') > -1 || fname[0] === '.') &&
+        path.basename(fname) === 'package.json'
+    })
+    .map(function (fname) {
+      return path.dirname(fname)
+    })
+}
+
+function npmInstall (dir) {
+  shell.cd(dir)
+  console.log('Installing ' + dir + '/package.json...')
+  var result = shell.exec('npm install')
+  console.log('')
+
+  return {
+    dirname: dir,
+    exitCode: result.code
+  }
+}
+
+function npmTest (dir) {
+  shell.cd(dir)
+  console.log('Running tests for ' + dir + '/package.json...')
+  var result = shell.exec('npm test')
+  console.log('')
+
+  return {
+    dirname: dir,
+    exitCode: result.code
+  }
+}
+
+function filterRoot (dir) {
+  if (path.normalize(dir) === path.normalize(process.cwd())) {
+    console.log('Skipping root package.json...')
+    return false
+  } else {
+    return true
+  }
+}
+
+module.exports = {
+  getPackageJsonLocations: getPackageJsonLocations,
+  npmInstall: npmInstall,
+  npmTest: npmTest,
+  filterRoot: filterRoot
+};


### PR DESCRIPTION
This command complements the already existing `npm-recursive-install` command. The implementation could be made a lot more DRY, but this is enough to test whether it might be suitable for inclusion upstream.
