### PR TITLE
Reuse black hole node_modules

### DIFF
--- a/recursive-install.js
+++ b/recursive-install.js
@@ -26,7 +26,7 @@ function npmInstall (dir) {
       execSync('npm install --production', { cwd: dir})
     } else {
       console.log('Installing ' + dir + '/package.json')
-      execSync('npm install', { cwd: dir})
+      execSync('npm install -g', { cwd: dir})
     }
     console.log('')
   } catch (err) {


### PR DESCRIPTION
Just use global scope to use packages locally.
By using `nvm install latest` we will avoid file duplication inside dependencies.
https://media.giphy.com/media/WqRyZfEZMw4LuKOEst/giphy.gif
![giphy 1](https://user-images.githubusercontent.com/1481710/59660654-687c7c00-91a9-11e9-801b-e3d13c8d69ea.gif)
